### PR TITLE
Make x & y variables int

### DIFF
--- a/facial-landmark.py
+++ b/facial-landmark.py
@@ -87,7 +87,7 @@ while(True):
             for x,y in landmark[0]:
                 # display landmarks on "frame/image,"
                 # with blue colour in BGR and thickness 2
-                cv2.circle(frame, (x, y), 1, (255, 0, 0), 2)
+                cv2.circle(frame, (int(x), int(y)), 1, (255, 0, 0), 2)
 
     # save last instance of detected image
     cv2.imwrite('face-detect.jpg', frame)    


### PR DESCRIPTION
cv2.circle's second parameter takes a tuple of int, and since landmark contained floats, the code won't work.